### PR TITLE
Repos now will emit events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "pushover": "*",
     "cli-listener": "*",
     "commander": "*",
-    "git-emit": "0.0.0"
+    "git-emit": "0.0.0",
+    "event-proxy": "0.0.1"
   },
   "keywords": [
     "git",


### PR DESCRIPTION
Events are based on substack/node-git-emit
plus, additionally, if available, last commit object will be passed. 
